### PR TITLE
Doplnění možnosti zadání "DP" parametru bez úvodní nuly

### DIFF
--- a/custom_components/egddistribuce/downloader.py
+++ b/custom_components/egddistribuce/downloader.py
@@ -29,7 +29,7 @@ def parseHDO(jsonHDO,HDORegion,HDO_A,HDO_B,HDO_DP):
     HDO_Date_Do=[]
     HDO_Cas_Od = []
     HDO_Cas_Do = []
-    output_hdo_dict = [x for x in jsonHDO if x['A'] == HDO_A and x['B'] == HDO_B and x['DP'] == HDO_DP and x['region'] == HDORegion]
+    output_hdo_dict = [x for x in jsonHDO if x['A'] == HDO_A and x['B'] == HDO_B and (x['DP'] == HDO_DP or x['DP'] == '0' + HDO_DP) and x['region'] == HDORegion]
     dateNow = datetime.datetime.now()
     HDOStatus=False
 


### PR DESCRIPTION
Trochu jsem se zadrbal na tom, že jsem do konfigurace zadal "**DP**" parametr bez nuly na začátku ("**6**" místo "**06**"). Sice je to s nulou v README, ale na elektroměru je to bez ní, tak mě to zmátlo 🙂 Proto posílám úpravu, aby to na té nule nebylo závislé.

Přeji pěkný den 🙂