### PR TITLE
Fix unverified warning in HA

### DIFF
--- a/custom_components/egddistribuce/binary_sensor.py
+++ b/custom_components/egddistribuce/binary_sensor.py
@@ -123,12 +123,12 @@ class EgdDistribuce(BinarySensorEntity):
 
     @Throttle(MIN_TIME_BETWEEN_SCANS)
     def update(self):
-        responseRegion = requests.get(downloader.get_region(), verify=False)
+        responseRegion = requests.get(downloader.get_region(), verify=True)
         if responseRegion.status_code == 200:
             self.responseRegionJson = responseRegion.json()
             self.region = downloader.parse_region(
                 self.responseRegionJson, self.psc)
-            responseHDO = requests.get(downloader.get_HDO(), verify=False)
+            responseHDO = requests.get(downloader.get_HDO(), verify=True)
             if responseHDO.status_code == 200:
                 self.responseHDOJson = responseHDO.json()
                 self.last_update_success = True


### PR DESCRIPTION
This fixes a potential security flaw -  `InsecureRequestWarning: Unverified HTTPS request is being made to host 'hdo.distribuce24.cz'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings warnings.warn(`
If there was a security flaw in the parsing code, attacker would have it easier to provide falsified json.