### PR TITLE
Fix the binary sensor name that 'cena_distribuce_eg_d works correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ binary_sensor:
 # HDO example for smart meter with code `d57`
 binary_sensor:
   - platform: egddistribuce
-    name: egdTAR
+    name: hdo
     psc: "smart"
     code_a: "d57"
     price_vt: "2.11469"


### PR DESCRIPTION
With 'egdTAR' name the later `cena_distribuce_eg_d` sensor does not return correct value.